### PR TITLE
Migrate audit config to new policy format

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,10 @@
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "ergebnis/composer-normalize": true
         },
-        "audit": {
-            "abandoned": "report"
+        "policy": {
+            "abandoned": {
+                "audit": "report"
+            }
         },
         "sort-packages": true
     }

--- a/composer.lock
+++ b/composer.lock
@@ -1084,5 +1084,5 @@
         "php": "~8.2.0"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
Migrates config.audit to the unified config.policy object introduced in Composer 2.10. This prepares the project for Composer 2.11 and avoids future deprecation warnings.

https://blog.packagist.com/composer-2-10-release/
https://getcomposer.org/doc/06-config.md#audit-1